### PR TITLE
Add ignore namespace option as a flag

### DIFF
--- a/cli/cmd/resources/instrumentor.go
+++ b/cli/cmd/resources/instrumentor.go
@@ -357,6 +357,11 @@ func NewInstrumentorDeployment(version string, telemetryEnabled bool) *appsv1.De
 		"--health-probe-bind-address=:8081",
 		"--metrics-bind-address=127.0.0.1:8080",
 		"--leader-elect",
+		"--ignore-namespace=odigos-system",
+		"--ignore-namespace=kube-system",
+		"--ignore-namespace=local-path-storage",
+		"--ignore-namespace=istio-system",
+		"--ignore-namespace=linkerd",
 		fmt.Sprintf("--lang-detector-tag=%s", version),
 		fmt.Sprintf("--lang-detector-image=%s", langDetectorImage),
 	}

--- a/instrumentor/controllers/common.go
+++ b/instrumentor/controllers/common.go
@@ -17,6 +17,7 @@ import (
 )
 
 var (
+	// IgnoredNamespaces have [odigos-system kube-system local-path-storage istio-system linkerd] by default
 	IgnoredNamespaces []string
 	SkipAnnotation    = "odigos.io/skip"
 )

--- a/instrumentor/controllers/common.go
+++ b/instrumentor/controllers/common.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	IgnoredNamespaces = []string{"kube-system", "local-path-storage", "istio-system", "linkerd", consts.DefaultNamespace}
+	IgnoredNamespaces []string
 	SkipAnnotation    = "odigos.io/skip"
 )
 

--- a/instrumentor/controllers/common.go
+++ b/instrumentor/controllers/common.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// IgnoredNamespaces have [odigos-system kube-system local-path-storage istio-system linkerd] by default
-	IgnoredNamespaces []string
+	IgnoredNamespaces map[string]bool
 	SkipAnnotation    = "odigos.io/skip"
 
 	DeploymentPrefix  = "deployment-"
@@ -26,18 +26,13 @@ var (
 )
 
 func shouldSkip(annotations map[string]string, namespace string) bool {
-	for k, v := range annotations {
-		if k == SkipAnnotation && v == "true" {
-			return true
-		}
+	if val, ok := annotations[SkipAnnotation]; ok && val == "true" {
+		return true
 	}
 
-	for _, ns := range IgnoredNamespaces {
-		if namespace == ns {
-			return true
-		}
+	if _, ok := IgnoredNamespaces[namespace]; ok {
+		return true
 	}
-
 	return false
 }
 

--- a/instrumentor/main.go
+++ b/instrumentor/main.go
@@ -80,7 +80,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	controllers.IgnoredNamespaces = ignoredNameSpaces
+	controllers.IgnoredNamespaces = generateIgnoredNamesSpacesMap(ignoredNameSpaces)
 	setupLog.Info("ignored namespaces from flags", "namespaces", ignoredNameSpaces)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -158,4 +158,13 @@ func (s *stringslice) Set(val string) error {
 
 func (s *stringslice) String() string {
 	return strings.Join(*s, " ")
+}
+
+func generateIgnoredNamesSpacesMap(nss []string) map[string]bool {
+	m := make(map[string]bool)
+	for _, v := range nss {
+		m[v] = true
+	}
+
+	return m
 }

--- a/instrumentor/main.go
+++ b/instrumentor/main.go
@@ -78,6 +78,8 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	controllers.IgnoredNamespaces = ignoredNameSpaces
+	setupLog.Info("ignored namespaces from flags", "namespaces", ignoredNameSpaces)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,

--- a/instrumentor/main.go
+++ b/instrumentor/main.go
@@ -75,10 +75,9 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	controllers.IgnoredNamespaces = append(controllers.IgnoredNamespaces, []string(ignoredNameSpaces)...)
-
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	controllers.IgnoredNamespaces = ignoredNameSpaces
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,


### PR DESCRIPTION
Roadmap:

- [x] Add namespace ignoring for controller
- [x] Add namespace option in `values.yaml` on https://github.com/keyval-dev/odigos-charts
- [x] Test Cases
  - [x] Default namespaces from the code (moved to helm)
  - [x] Single namespace is given
  - [x] No namespace is given
  - [x] Multiple namespace is given
  - [x] Single non-existing namespace is given
  - [x] Multiple namespaces given but one is not existing
  - [x] Multiple namespaces given but more than one are not existing