### PR TITLE
Add missing option in CLI instruction

### DIFF
--- a/cli/cmd/resources/instrumentor.go
+++ b/cli/cmd/resources/instrumentor.go
@@ -352,18 +352,16 @@ func NewInstrumentorClusterRoleBinding(ns string) *rbacv1.ClusterRoleBinding {
 	}
 }
 
-func NewInstrumentorDeployment(version string, telemetryEnabled bool) *appsv1.Deployment {
+func NewInstrumentorDeployment(version string, telemetryEnabled bool, ignoredNamespaces []string) *appsv1.Deployment {
 	args := []string{
 		"--health-probe-bind-address=:8081",
 		"--metrics-bind-address=127.0.0.1:8080",
 		"--leader-elect",
-		"--ignore-namespace=odigos-system",
-		"--ignore-namespace=kube-system",
-		"--ignore-namespace=local-path-storage",
-		"--ignore-namespace=istio-system",
-		"--ignore-namespace=linkerd",
 		fmt.Sprintf("--lang-detector-tag=%s", version),
 		fmt.Sprintf("--lang-detector-image=%s", langDetectorImage),
+	}
+	for _, v := range ignoredNamespaces {
+		args = append(args, fmt.Sprintf("--ignore-namespace=%s", v))
 	}
 
 	if !telemetryEnabled {

--- a/instrumentor/controllers/common.go
+++ b/instrumentor/controllers/common.go
@@ -17,7 +17,9 @@ import (
 )
 
 var (
-	// IgnoredNamespaces have [odigos-system kube-system local-path-storage istio-system linkerd] by default
+	// IgnoredNamespaces is filled from either:
+	//   - cmd.DefaultIgnoredNamespaces
+	//   - Helm chart's instrumentor.ignoredNamespaces field
 	IgnoredNamespaces map[string]bool
 	SkipAnnotation    = "odigos.io/skip"
 


### PR DESCRIPTION
I noticed that I forgot to add cli option in odigos installation. It's totally OK to ignore this PR, with time Odigos will have lot of options and you may want to carefully choose how to do it.