### PR TITLE
bugfix: Remove secret when deleting destination

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+.vscode

--- a/ui/pages/api/dest/[destname].ts
+++ b/ui/pages/api/dest/[destname].ts
@@ -47,6 +47,21 @@ async function DeleteDest(req: NextApiRequest, res: NextApiResponse) {
     "destinations",
     req.query.destname as string
   );
+
+  // if secret with name req.query.destname exists, delete it
+  const coreApi = kc.makeApiClient(k8s.CoreV1Api);
+  const secret = await coreApi.readNamespacedSecret(
+    req.query.destname as string,
+    process.env.CURRENT_NS || "odigos-system"
+  );
+
+  if (secret) {
+    await coreApi.deleteNamespacedSecret(
+      req.query.destname as string,
+      process.env.CURRENT_NS || "odigos-system"
+    );
+  }
+
   return res.status(200).json({ success: true });
 }
 


### PR DESCRIPTION
This PR adds the removal of a secret (if exists) when deleting a destination.
This bug caused the creation of a destination with the same name as the deleted destination to fail.