### PR TITLE
fix: Panic on null resource limits

### DIFF
--- a/instrumentor/patch/dotnet.go
+++ b/instrumentor/patch/dotnet.go
@@ -15,6 +15,10 @@ func (d *dotNetPatcher) Patch(podSpec *v1.PodTemplateSpec, instrumentation *odig
 	var modifiedContainers []v1.Container
 	for _, container := range podSpec.Spec.Containers {
 		if shouldPatch(instrumentation, common.DotNetProgrammingLanguage, container.Name) {
+			if container.Resources.Limits == nil {
+				container.Resources.Limits = make(map[v1.ResourceName]resource.Quantity)
+			}
+
 			container.Resources.Limits["instrumentation.odigos.io/dotnet"] = resource.MustParse("1")
 		}
 

--- a/instrumentor/patch/golang.go
+++ b/instrumentor/patch/golang.go
@@ -12,7 +12,7 @@ import (
 const (
 	golangKernelDebugVolumeName = "kernel-debug"
 	golangKernelDebugHostPath   = "/sys/kernel/debug"
-	golangAgentName             = "keyval/otel-go-agent:v0.6.3"
+	golangAgentName             = "keyval/otel-go-agent:v0.6.4"
 	golangExporterEndpoint      = "OTEL_EXPORTER_OTLP_ENDPOINT"
 	golangServiceNameEnv        = "OTEL_SERVICE_NAME"
 	golangTargetExeEnv          = "OTEL_TARGET_EXE"

--- a/instrumentor/patch/java.go
+++ b/instrumentor/patch/java.go
@@ -15,6 +15,10 @@ func (j *javaPatcher) Patch(podSpec *v1.PodTemplateSpec, instrumentation *odigos
 	var modifiedContainers []v1.Container
 	for _, container := range podSpec.Spec.Containers {
 		if shouldPatch(instrumentation, common.JavaProgrammingLanguage, container.Name) {
+			if container.Resources.Limits == nil {
+				container.Resources.Limits = make(map[v1.ResourceName]resource.Quantity)
+			}
+
 			container.Resources.Limits["instrumentation.odigos.io/java"] = resource.MustParse("1")
 		}
 

--- a/instrumentor/patch/nodejs.go
+++ b/instrumentor/patch/nodejs.go
@@ -15,6 +15,10 @@ func (n *nodeJsPatcher) Patch(podSpec *v1.PodTemplateSpec, instrumentation *odig
 	var modifiedContainers []v1.Container
 	for _, container := range podSpec.Spec.Containers {
 		if shouldPatch(instrumentation, common.JavascriptProgrammingLanguage, container.Name) {
+			if container.Resources.Limits == nil {
+				container.Resources.Limits = make(map[v1.ResourceName]resource.Quantity)
+			}
+
 			container.Resources.Limits["instrumentation.odigos.io/nodejs"] = resource.MustParse("1")
 		}
 

--- a/instrumentor/patch/python.go
+++ b/instrumentor/patch/python.go
@@ -26,6 +26,10 @@ func (p *pythonPatcher) Patch(podSpec *v1.PodTemplateSpec, instrumentation *odig
 	var modifiedContainers []v1.Container
 	for _, container := range podSpec.Spec.Containers {
 		if shouldPatch(instrumentation, common.PythonProgrammingLanguage, container.Name) {
+			if container.Resources.Limits == nil {
+				container.Resources.Limits = make(map[v1.ResourceName]resource.Quantity)
+			}
+
 			container.Resources.Limits["instrumentation.odigos.io/python"] = resource.MustParse("1")
 		}
 

--- a/odiglet/example-app.yaml
+++ b/odiglet/example-app.yaml
@@ -59,7 +59,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         - name: grpc-instrumentation
-          image: keyval/otel-go-agent:v0.6.3
+          image: keyval/otel-go-agent:v0.6.4
           env:
             - name: OTEL_TARGET_EXE
               value: /workspace/app


### PR DESCRIPTION
This PR fixes a bug where instrumentation would panic when a deployment / statefulset has a null `.spec.containers[].resources.limits`
