### PR TITLE
destinations page: add search #37

### DIFF
--- a/ui/components/DestsGrid.tsx
+++ b/ui/components/DestsGrid.tsx
@@ -14,6 +14,9 @@ export default function DestsGrid({ vendors, title }: DestsGridProps) {
         {vendors.map((dest: ObservabilityVendor) => {
           return <DestCard key={dest.name} {...dest} />;
         })}
+        {
+          vendors.length < 1 && <div>No data found</div>
+        }
       </div>
     </div>
   );

--- a/ui/pages/dest/new/index.tsx
+++ b/ui/pages/dest/new/index.tsx
@@ -1,25 +1,81 @@
 import DestsGrid from "@/components/DestsGrid";
 import { getConfiguration } from "@/utils/config";
 import Vendors, { VendorType } from "@/vendors/index";
+import { Combobox } from "@headlessui/react";
 import type { NextPage } from "next";
+import { useState } from "react";
 
 const AddNewDestinationPage: NextPage = () => {
+
+  const people = [
+  'Durward Reynolds',
+  'Kenton Towne',
+  'Therese Wunsch',
+  'Benedict Kessler',
+  'Katelyn Rohan',
+]
+
+
+  const [selectedDest, setSelectedDest] = useState(Vendors[0])
+  const [query, setQuery] = useState('')
+
+  const filteredDest =
+    query === ''
+      ? Vendors
+      : Vendors.filter((vendor) => {
+          return vendor.displayName.toLowerCase().includes(query.toLowerCase()) || vendor.name.toLowerCase().includes(query.toLowerCase())
+        })
+      
+
   return (
     <div className="flex flex-col">
+      <div className="flex flex-col md:flex-row">
       <div className="text-4xl font-medium">Add New Destination</div>
-      <div className="text-2xl mt-4 mb-6">
+      <div className="mx-1 md:mx-20 z-30 bg-white relative">
+      <Combobox value={selectedDest} onChange={setSelectedDest}>
+        <Combobox.Input className="w-full md:w-[600px] rounded-[2px] overflow-hidden list-none" placeholder="Search a destination" onChange={(event) => setQuery(event.target.value)} />
+          <Combobox.Options>
+            {filteredDest.map((vendor) => (
+              <Combobox.Option onClick={() => setQuery(vendor.name)} key={vendor?.name} value={vendor.name}>
+                {vendor.name}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+      </Combobox>
+      </div>
+      
+      </div>
+      <div className="text-2xl mt-24 mb-6 absolute">
         Choose an observability backend from the list
       </div>
-      <div className="space-y-10">
-        <DestsGrid
-          vendors={Vendors.filter((v) => v.type === VendorType.MANAGED)}
-          title="Managed"
-        />
-        <DestsGrid
-          vendors={Vendors.filter((v) => v.type === VendorType.HOSTED)}
-          title="Self-hosted"
-        />
-      </div>
+
+      {query && 
+          <div className="space-y-10 absolute mt-36">
+              <>
+                <DestsGrid
+                  vendors={filteredDest.filter((v) => v.type === VendorType.MANAGED)}
+                  title="Managed"
+                />   
+                <DestsGrid
+                  vendors={filteredDest.filter((v) => v.type === VendorType.HOSTED)}
+                  title="Self-hosted"
+                />
+              </>
+          </div>
+      }
+
+      { !query && 
+        <div className="space-y-10 absolute mt-36">
+          <DestsGrid
+            vendors={Vendors.filter((v) => v.type === VendorType.MANAGED)}
+            title="Managed"
+          />
+          <DestsGrid
+            vendors={Vendors.filter((v) => v.type === VendorType.HOSTED)}
+            title="Self-hosted"
+          />
+        </div>
+      }
     </div>
   );
 };

--- a/ui/pages/dest/new/index.tsx
+++ b/ui/pages/dest/new/index.tsx
@@ -7,15 +7,6 @@ import { useState } from "react";
 
 const AddNewDestinationPage: NextPage = () => {
 
-  const people = [
-  'Durward Reynolds',
-  'Kenton Towne',
-  'Therese Wunsch',
-  'Benedict Kessler',
-  'Katelyn Rohan',
-]
-
-
   const [selectedDest, setSelectedDest] = useState(Vendors[0])
   const [query, setQuery] = useState('')
 
@@ -36,7 +27,7 @@ const AddNewDestinationPage: NextPage = () => {
         <Combobox.Input className="w-full md:w-[600px] rounded-[2px] overflow-hidden list-none" placeholder="Search a destination" onChange={(event) => setQuery(event.target.value)} />
           <Combobox.Options>
             {filteredDest.map((vendor) => (
-              <Combobox.Option onClick={() => setQuery(vendor.name)} key={vendor?.name} value={vendor.name}>
+              <Combobox.Option onClick={() => setQuery(vendor.name)} key={vendor.name} value={vendor.name}>
                 {vendor.name}
               </Combobox.Option>
             ))}


### PR DESCRIPTION
Feat: add destination search functions to odigos destination page

- Now users can search using either the short name or the display name

https://user-images.githubusercontent.com/44473671/235269380-2b4c230c-3225-4bc4-bb42-9a9e3fc2f894.mp4

