### PR TITLE
Add stale issues github workflow

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,22 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 6 * * 1'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 60
+          days-before-close: 30
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          close-issue-message: 'This issue was closed because it has been stale for 30 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          close-pr-message: 'This PR was closed because it has been stale for 30 days with no activity.'
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: never-stale,bug
+          exempt-pr-labels: never-stale,bug
+          exempt-draft-pr: true


### PR DESCRIPTION
This PR adds a new GitHub workflow that handles the closing of stale issues and pull requests.