### PR TITLE
fix: Corrected console output log

### DIFF
--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -63,20 +63,23 @@ var uninstallCmd = &cobra.Command{
 		// Wait for namespace to be deleted
 		waitForNamespaceDeletion(ctx, client, ns)
 
-		l := log.Print("Rolling back odigos changes to pods\n")
+		l := log.Print("Rolling back odigos changes to pods")
 		err = rollbackPodChanges(ctx, client)
 		if err != nil {
 			l.Error(err)
+		} else {
+			l.Success()
 		}
-
-		l = log.Print("Rolling back odigos changes to namespaces\n")
+		
+		l = log.Print("Rolling back odigos changes to namespaces")
 		err = rollbackNamespaceChanges(ctx, client)
 		if err != nil {
 			l.Error(err)
+		} else {
+			l.Success()
 		}
 
-		l.Success()
-
+		
 		fmt.Printf("\n\u001B[32mSUCCESS:\u001B[0m Odigos uninstalled.\n")
 	},
 }


### PR DESCRIPTION
# Fixes issue:
- Issue: https://github.com/keyval-dev/odigos/issues/614
- Correction in output log

<br> 

# Changes made:
- Removed ```\n``` from the ```log.print()``` to print the Tic mark(V) in same line
- Added ```l.Success()``` after ```log.Print("Rolling back odigos changes to namespaces")``` which is may be missing according to code
- Added ```l.Success()``` inside the ```else()``` block

<br> 

# Files changed:
- **uninstall.go** (cli/cmd/uninstall.go)

<br>

# Total changes: 8