### PR TITLE
Updated blog link

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -27,7 +27,7 @@
     {
       "name": "Blog",
       "icon": "newspaper",
-      "url": "https://keyval.dev/blog/"
+      "url": "https://odigos.io/blog"
     }
   ],
   "navigation": [


### PR DESCRIPTION
I updated `mint.json` https://keyval.dev/blog/  to https://odigos.io/blog. Because when visiting the https://keyval.dev/blog/ come up with odigos.io home page. 

## Screenshort
![preview](https://github.com/keyval-dev/odigos/assets/43641536/6ca25a01-5c64-450a-ae3d-0f43450b7782)
