### PR TITLE
Chore: Typo fixed in multiple files

### DIFF
--- a/cli/cmd/observability.go
+++ b/cli/cmd/observability.go
@@ -93,7 +93,7 @@ var (
 func isValidBackend(name string) error {
 	avail := backend.GetAvailableBackends()
 	if name == "" {
-		return fmt.Errorf("please specifiy an observability backend via --backend flag, choose one from %+v", avail)
+		return fmt.Errorf("please specify an observability backend via --backend flag, choose one from %+v", avail)
 	}
 
 	for _, s := range avail {

--- a/cli/cmd/observability/backend/datadog.go
+++ b/cli/cmd/observability/backend/datadog.go
@@ -27,7 +27,7 @@ func (d *Datadog) ParseFlags(cmd *cobra.Command, selectedSignals []common.Observ
 
 	_, err := url.Parse(targetUrl)
 	if err != nil {
-		return nil, fmt.Errorf("invalud url specified: %s", err)
+		return nil, fmt.Errorf("invalid url specified: %s", err)
 	}
 
 	if !strings.Contains(targetUrl, "datadoghq.com") {

--- a/cli/cmd/observability/backend/grafana.go
+++ b/cli/cmd/observability/backend/grafana.go
@@ -46,7 +46,7 @@ func (g *Grafana) ParseFlags(cmd *cobra.Command, selectedSignals []common.Observ
 
 			_, err := url.Parse(tempoUrl)
 			if err != nil {
-				return nil, fmt.Errorf("invalud tempo url specified: %s", err)
+				return nil, fmt.Errorf("invalid tempo url specified: %s", err)
 			}
 
 			tempoUser := cmd.Flag(GrafanaTempoUserFlag).Value.String()
@@ -64,7 +64,7 @@ func (g *Grafana) ParseFlags(cmd *cobra.Command, selectedSignals []common.Observ
 
 			_, err := url.Parse(rwUrl)
 			if err != nil {
-				return nil, fmt.Errorf("invalud remotewrite url specified: %s", err)
+				return nil, fmt.Errorf("invalid remotewrite url specified: %s", err)
 			}
 
 			promUser := cmd.Flag(GrafanaPromUserFlag).Value.String()
@@ -81,7 +81,7 @@ func (g *Grafana) ParseFlags(cmd *cobra.Command, selectedSignals []common.Observ
 
 			_, err := url.Parse(lokiUrl)
 			if err != nil {
-				return nil, fmt.Errorf("invalud loki url specified: %s", err)
+				return nil, fmt.Errorf("invalid loki url specified: %s", err)
 			}
 
 			lokiUser := cmd.Flag(GrafanaLokiUserFlag).Value.String()

--- a/cli/cmd/observability/backend/loki.go
+++ b/cli/cmd/observability/backend/loki.go
@@ -21,7 +21,7 @@ func (l *Loki) ParseFlags(cmd *cobra.Command, selectedSignals []common.Observabi
 
 	_, err := url.Parse(lokiUrl)
 	if err != nil {
-		return nil, fmt.Errorf("invalud loki URL specified: %s", err)
+		return nil, fmt.Errorf("invalid loki URL specified: %s", err)
 	}
 
 	return &ObservabilityArgs{

--- a/cli/cmd/observability/backend/prometheus.go
+++ b/cli/cmd/observability/backend/prometheus.go
@@ -21,7 +21,7 @@ func (p *Prometheus) ParseFlags(cmd *cobra.Command, selectedSignals []common.Obs
 
 	_, err := url.Parse(rwUrl)
 	if err != nil {
-		return nil, fmt.Errorf("invalud prometheus remote write URL specified: %s", err)
+		return nil, fmt.Errorf("invalid prometheus remote write URL specified: %s", err)
 	}
 
 	return &ObservabilityArgs{

--- a/cli/cmd/observability/backend/tempo.go
+++ b/cli/cmd/observability/backend/tempo.go
@@ -21,7 +21,7 @@ func (t *Tempo) ParseFlags(cmd *cobra.Command, selectedSignals []common.Observab
 
 	_, err := url.Parse(tempoUrl)
 	if err != nil {
-		return nil, fmt.Errorf("invalud tempo URL specified: %s", err)
+		return nil, fmt.Errorf("invalid tempo URL specified: %s", err)
 	}
 
 	return &ObservabilityArgs{

--- a/docs/adding-new-dest.mdx
+++ b/docs/adding-new-dest.mdx
@@ -108,7 +108,7 @@ toObjects = (req: NextApiRequest) => {
   Notice that Kubernetes requires that the secret data be base64 encoded.
 </Note>
 
-7. Add the mthod `mapDataToFields` which converts the data received from the
+7. Add the method `mapDataToFields` which converts the data received from the
    Kubernetes data store to the data that will be displayed in the UI. This
    method is invoked when user edits the destination in the UI.
 

--- a/docs/backends/lightstep.mdx
+++ b/docs/backends/lightstep.mdx
@@ -2,7 +2,7 @@
 title: "Lightstep"
 ---
 
-## Obtaining Lightstep Acces Token
+## Obtaining Lightstep Access Token
 
 Go to **⚙️ > Access Tokens** and click **Create New**
 

--- a/docs/backends/newrelic.mdx
+++ b/docs/backends/newrelic.mdx
@@ -12,6 +12,6 @@ For key type select **Ingest - License**, give a name to your key and press **Cr
 
 ![](/backends/images/newrelic2.png)
 
-## Cofiguring New Relic Backend
+## Configuring New Relic Backend
 
 In the New Relic backend configuration page, enter the **License Key** from previous step and name the backend.

--- a/docs/usage-reports.mdx
+++ b/docs/usage-reports.mdx
@@ -3,7 +3,7 @@ title: "Usage report"
 ---
 
 Odigos sends non-sensitive, non-personally identifiable information to our system.
-This informations helps Odigos maintainers to understand how the open-source community runs Odigos and
+This information helps Odigos maintainers to understand how the open-source community runs Odigos and
 improve the project.
 
 ### Disabling the report


### PR DESCRIPTION
This PR fix the typos that is seen in multiple files.

```pseudo
specifiy > specify
invalud > invalid
mthod > method
informations > information
Cofiguring > Configuring
```