### PR TITLE
Fix/uninstall log

### DIFF
--- a/cli/cmd/resources/namespace.go
+++ b/cli/cmd/resources/namespace.go
@@ -29,7 +29,9 @@ func GetOdigosNamespace(client *kube.Client, ctx context.Context) (string, error
 		return "", err
 	}
 
-	if len(namespaces.Items) != 1 {
+	if len(namespaces.Items) == 0 {
+		return "", fmt.Errorf("odigos is not currently installed in the cluster, so there is nothing to uninstall")
+	} else if len(namespaces.Items) != 1 {
 		return "", fmt.Errorf("expected to get 1 namespace got %d", len(namespaces.Items))
 	}
 

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -39,17 +39,10 @@ var uninstallCmd = &cobra.Command{
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil {
-			errString := err.Error()
-
-			if errString[len(errString) - 1] == '0' {
-				errMessage := "\033[31mERROR\033[0m Odigos is not currently installed in the cluster, so there is nothing to uninstall"
-				fmt.Println(errMessage)
-			} else {
-				fmt.Println("\033[31mERROR\033[0m", err)
-			}
+			fmt.Println("\033[31mERROR\033[0m", err)
 			os.Exit(1)
 		}
-		
+
 		fmt.Printf("About to uninstall Odigos from namespace %s\n", ns)
 		confirmed, err := confirm.Ask("Are you sure?")
 		if err != nil || !confirmed {

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/keyval-dev/odigos/cli/pkg/log"
 	"github.com/keyval-dev/odigos/common/consts"
 	v1 "k8s.io/api/core/v1"
+	// "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -36,18 +38,19 @@ var uninstallCmd = &cobra.Command{
 		}
 		ctx := cmd.Context()
 
-		errMessage := fmt.Errorf("Odigos is not installed in the cluster")
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			errString := err.Error()
+
+			if errString[len(errString) - 1] == '0' {
+				errMessage := "\033[31mERROR\033[0m Odigos is not currently installed in the cluster, so there is nothing to uninstall"
 				fmt.Println(errMessage)
 			} else {
-				ns = consts.DefaultNamespace
-				fmt.Println(err)
+				fmt.Println("\033[31mERROR\033[0m", err)
 			}
 			os.Exit(1)
 		}
-
+		
 		fmt.Printf("About to uninstall Odigos from namespace %s\n", ns)
 		confirmed, err := confirm.Ask("Are you sure?")
 		if err != nil || !confirmed {

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -38,8 +38,11 @@ var uninstallCmd = &cobra.Command{
 		ctx := cmd.Context()
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
-		if err != nil {
-			fmt.Println("\033[31mERROR\033[0m", err)
+		if resources.IsErrNoOdigosNamespaceFound(err) {
+			fmt.Println("\033[31mERROR\033[0m odigos is not currently installed in the cluster, so there is nothing to uninstall")
+			os.Exit(1)
+		} else if !resources.IsErrNoOdigosNamespaceFound(err) && err != nil{
+			fmt.Printf("\033[31mERROR\033[0m Failed to check if Odigos is already uninstalled: %s\n", err)
 			os.Exit(1)
 		}
 

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -36,9 +36,16 @@ var uninstallCmd = &cobra.Command{
 		}
 		ctx := cmd.Context()
 
+		errMessage := fmt.Errorf("Odigos is not installed in the cluster")
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil {
-			ns = consts.DefaultNamespace
+			if errors.IsNotFound(err) {
+				fmt.Println(errMessage)
+			} else {
+				ns = consts.DefaultNamespace
+				fmt.Println(err)
+			}
+			os.Exit(1)
 		}
 
 		fmt.Printf("About to uninstall Odigos from namespace %s\n", ns)

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -14,7 +14,6 @@ import (
 	"github.com/keyval-dev/odigos/cli/pkg/log"
 	"github.com/keyval-dev/odigos/common/consts"
 	v1 "k8s.io/api/core/v1"
-	// "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 


### PR DESCRIPTION
# Fixes issue:
- Issue: #658 
- Update the error message for uninstall of odigos if it is not installed

<br>

# Changes made:
- Updated the code such that if no **Namepace** is found then print the updated error message and exit
- Other changes:
  - Previously the code continues ```defaultnamespace``` but the updated code print the error and exit

<br>

### Files changed:
- **uninstall.go** (cli/cmd/uninstall.go)
