### PR TITLE
fix: exit if odigos is already installed

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/keyval-dev/odigos/cli/pkg/containers"
@@ -54,6 +55,12 @@ This command will install k8s components that will auto-instrument your applicat
 		cmd.Flags().StringSliceVar(&ignoredNamespaces, "ignore-namespace", DefaultIgnoredNamespaces, "--ignore-namespace foo logging")
 		fmt.Printf("Installing Odigos version %s in namespace %s ...\n", versionFlag, ns)
 
+		nsflag, err := resources.GetOdigosNamespace(client, ctx)
+		if  err == nil {
+			fmt.Printf("\033[31mERROR\033[0m Odigos is already installed in namespace \"%s\". If you wish to re-install, run \"odigos uninstall\" first.\n", nsflag)
+			os.Exit(1)
+		}
+		
 		isOdigosCloud := odigosCloudApiKeyFlag != ""
 		createKubeResourceWithLogging(ctx, fmt.Sprintf("Creating namespace %s", ns),
 			client, cmd, ns, createNamespace)

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -59,6 +59,9 @@ This command will install k8s components that will auto-instrument your applicat
 		if  err == nil {
 			fmt.Printf("\033[31mERROR\033[0m Odigos is already installed in namespace \"%s\". If you wish to re-install, run \"odigos uninstall\" first.\n", nsflag)
 			os.Exit(1)
+		} else if !resources.IsErrNoOdigosNamespaceFound(err) {
+			fmt.Printf("\033[31mERROR\033[0m Failed to check if Odigos is already installed: %s\n", err)
+			os.Exit(1)
 		}
 		
 		isOdigosCloud := odigosCloudApiKeyFlag != ""

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -41,7 +41,8 @@ type ResourceCreationFunc func(ctx context.Context, cmd *cobra.Command, client *
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install Odigos",
-	Long:  `Install Odigos in your cluster. This command will install the Odigos CRDs, the Odigos Instrumentor, Scheduler, Autoscaler and Odiglet.`,
+	Long: `Install Odigos in your kubernetes cluster. 
+This command will install k8s components that will auto-instrument your applications with OpenTelemetry and send traces, metrics and logs to any telemetry backend`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		client, err := kube.CreateClient(cmd)
@@ -317,7 +318,7 @@ func createOwnTelemetryPipeline(ctx context.Context, cmd *cobra.Command, client 
 		return errors.New("odigos cloud api key is required for odigos own telemetry")
 	}
 
-	_, err := client.CoreV1().ConfigMaps(ns).Create(ctx, resources.NewOwnTelemetryConfigMapOtlpGrpc(ns), metav1.CreateOptions{})
+	_, err := client.CoreV1().ConfigMaps(ns).Create(ctx, resources.NewOwnTelemetryConfigMapOtlpGrpc(ns, versionFlag), metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/resources/namespace.go
+++ b/cli/cmd/resources/namespace.go
@@ -2,12 +2,16 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
 	"github.com/keyval-dev/odigos/cli/pkg/kube"
 	"github.com/keyval-dev/odigos/cli/pkg/labels"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var errNoOdigosNamespaceFound = errors.New("Odigos installation is not found in any namespace")
 
 func NewNamespace(name string) *v1.Namespace {
 	return &v1.Namespace{
@@ -29,9 +33,15 @@ func GetOdigosNamespace(client *kube.Client, ctx context.Context) (string, error
 		return "", err
 	}
 
-	if len(namespaces.Items) != 1 {
+	if len(namespaces.Items) == 0 {
+		return "", errNoOdigosNamespaceFound
+	} else if len(namespaces.Items) != 1 {
 		return "", fmt.Errorf("expected to get 1 namespace got %d", len(namespaces.Items))
 	}
 
 	return namespaces.Items[0].Name, nil
+}
+
+func IsErrNoOdigosNamespaceFound(err error) bool {
+	return errors.Is(err, errNoOdigosNamespaceFound)
 }

--- a/cli/cmd/resources/owntelemetry.go
+++ b/cli/cmd/resources/owntelemetry.go
@@ -46,7 +46,7 @@ func NewOwnTelemetryConfigMapDisabled() *corev1.ConfigMap {
 }
 
 // for odigos cloud which process own telemetry
-func NewOwnTelemetryConfigMapOtlpGrpc(ns string) *corev1.ConfigMap {
+func NewOwnTelemetryConfigMapOtlpGrpc(ns string, odigosVersion string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "ConfigMap",
@@ -60,6 +60,8 @@ func NewOwnTelemetryConfigMapOtlpGrpc(ns string) *corev1.ConfigMap {
 			"OTEL_EXPORTER_OTLP_INSECURE": "true",
 			// the http:// scheme is not actually used, it how the exporter is expecting the value with grpc
 			"OTEL_EXPORTER_OTLP_ENDPOINT": fmt.Sprintf("http://%s.%s:4317", ownTelemetryCollectorServiceName, ns),
+			// resource attributes
+			"OTEL_RESOURCE_ATTRIBUTES": fmt.Sprintf("odigos.version=%s", odigosVersion),
 		},
 	}
 }


### PR DESCRIPTION
# Fixes issue:
- Issue: #660 
- Update the error message for install of odigos if it is already installed

<br>

# Changes made:
- Updated the code such that if  ```Namepace``` is found then print the updated error message and exit

<br>

# Files changed:
- **install.go** (cli/cmd/install.go)