### PR TITLE
Refactor: remove deprecated command set-output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Set env
         id: vars
         run: |
-          echo name=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
-          echo name=$(echo $GITHUB_SHA | cut -c1-7) >> $GITHUB_OUTPUT
-          echo name=$(date -u +"%Y-%m-%dT%H:%M:%SZ") >> $GITHUB_OUTPUT
+          echo tag=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
+          echo short_commit=$(echo $GITHUB_SHA | cut -c1-7) >> $GITHUB_OUTPUT
+          echo date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") >> $GITHUB_OUTPUT
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21.0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Set env
         id: vars
         run: |
-          echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-          echo ::set-output name=short_commit::$(echo $GITHUB_SHA | cut -c1-7)
-          echo ::set-output name=date::$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo name=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
+          echo name=$(echo $GITHUB_SHA | cut -c1-7) >> $GITHUB_OUTPUT
+          echo name=$(date -u +"%Y-%m-%dT%H:%M:%SZ") >> $GITHUB_OUTPUT
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21.0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Set env
         id: vars
         run: |
-          echo tag=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
-          echo short_commit=$(echo $GITHUB_SHA | cut -c1-7) >> $GITHUB_OUTPUT
-          echo date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") >> $GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+          echo "short_commit=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
+          echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21.0'


### PR DESCRIPTION
# Fixes Issue: 
- Issue: #717 
- Remove the deprecated command ```set-output```, and update according to [GITHUB](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

<br>

# Changes made:
- Replaced the deprecated command with this format: **```echo "{name}={value}" >> $GITHUB_OUTPUT```**

<br>

# Files changed:
- **main.yml** (.github/workflows/main.yml)

<br>

# Total changes: 3