### PR TITLE
feat: add --yes flag to uninstall command

### DIFF
--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -46,11 +46,13 @@ var uninstallCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Printf("About to uninstall Odigos from namespace %s\n", ns)
-		confirmed, err := confirm.Ask("Are you sure?")
-		if err != nil || !confirmed {
-			fmt.Println("Aborting uninstall")
-			return
+		if !cmd.Flag("yes").Changed {
+			fmt.Printf("About to uninstall Odigos from namespace %s\n", ns)
+			confirmed, err := confirm.Ask("Are you sure?")
+			if err != nil || !confirmed {
+				fmt.Println("Aborting uninstall")
+				return
+			}
 		}
 
 		createKubeResourceWithLogging(ctx, "Uninstalling Odigos Deployments",
@@ -366,4 +368,5 @@ func uninstallNamespace(ctx context.Context, cmd *cobra.Command, client *kube.Cl
 
 func init() {
 	rootCmd.AddCommand(uninstallCmd)
+	uninstallCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 }

--- a/docs/cli/odigos_uninstall.mdx
+++ b/docs/cli/odigos_uninstall.mdx
@@ -24,6 +24,9 @@ Note: This command is not revertable and will delete any configuration you have 
     # Uninstall Odigos open-source or cloud from the cluster in your kubeconfig active context.
     odigos uninstall
 
+    # Uninstall Odigos without confirmation
+    odigos uninstall --yes
+    
     # Uninstall Odigos cloud from a specific cluster
     odigos uninstall --kubeconfig <path-to-kubeconfig>
 


### PR DESCRIPTION
# Fixes Issue:
- Issue: #728 
- Add ```--yes``` flag to odigos uninstall to skip the confirmation prompt

<br>

# Changes made:
- Defined a ```--yes``` flag in the ```init()``` function of uninstall.go file
- Added a condition to check if the flag value is changed or not, according to that continue for confirmation

<br>

# Files changed:
- ```uninstall.go``` (cli/cmd/uninstall.go)
- ```odigos_uninstall.mdx``` (docs/cli/odigos_uninstall.mdx)

<br>

# Total changes: 13

- [x] Tested the code