### PR TITLE
add the ability to add extra attributes to OTEL_RESOURCE_ATTRIBUTES

### DIFF
--- a/odiglet/pkg/instrumentation/instrumentlang/dotnet.go
+++ b/odiglet/pkg/instrumentation/instrumentlang/dotnet.go
@@ -38,7 +38,7 @@ func DotNet(deviceId string) *v1beta1.ContainerAllocateResponse {
 			collectorUrlEnv:       fmt.Sprintf("http://%s:%d", env.Current.NodeIP, consts.OTLPHttpPort),
 			serviceNameEnv:        deviceId,
 			exportTypeEnv:         "otlp",
-			resourceAttrEnv:       "odigos.device=dotnet",
+			resourceAttrEnv:       fmt.Sprintf("odigos.device=dotnet,%s", getAdditionalResourceAttributes()),
 			startupHookEnv:        startupHook,
 			additonalDepsEnv:      additonalDeps,
 			sharedStoreEnv:        sharedStore,

--- a/odiglet/pkg/instrumentation/instrumentlang/helper.go
+++ b/odiglet/pkg/instrumentation/instrumentlang/helper.go
@@ -1,0 +1,13 @@
+package instrumentlang
+
+import (
+	"os"
+)
+
+func getAdditionalResourceAttributes() string {
+	otelResourceAttributes, exists := os.LookupEnv("OTEL_RESOURCE_ATTRIBUTES")
+	if exists {
+		return otelResourceAttributes
+	}
+	return ""
+}

--- a/odiglet/pkg/instrumentation/instrumentlang/java.go
+++ b/odiglet/pkg/instrumentation/instrumentlang/java.go
@@ -2,6 +2,7 @@ package instrumentlang
 
 import (
 	"fmt"
+
 	"github.com/keyval-dev/odigos/odiglet/pkg/env"
 	"github.com/keyval-dev/odigos/odiglet/pkg/instrumentation/consts"
 	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -9,7 +10,7 @@ import (
 
 const (
 	otelResourceAttributesEnvVar = "OTEL_RESOURCE_ATTRIBUTES"
-	otelResourceAttrPatteern     = "service.name=%s,odigos.device=java"
+	otelResourceAttrPatteern     = "service.name=%s,odigos.device=java,%s"
 	javaToolOptionsEnvVar        = "JAVA_TOOL_OPTIONS"
 	javaOptsEnvVar               = "JAVA_OPTS"
 	javaToolOptionsPattern       = "-javaagent:/var/odigos/java/javaagent.jar " +
@@ -20,7 +21,7 @@ func Java(deviceId string) *v1beta1.ContainerAllocateResponse {
 	javaOpts := fmt.Sprintf(javaToolOptionsPattern, env.Current.NodeIP, consts.OTLPPort)
 	return &v1beta1.ContainerAllocateResponse{
 		Envs: map[string]string{
-			otelResourceAttributesEnvVar: fmt.Sprintf(otelResourceAttrPatteern, deviceId),
+			otelResourceAttributesEnvVar: fmt.Sprintf(otelResourceAttrPatteern, deviceId, getAdditionalResourceAttributes()),
 			javaToolOptionsEnvVar:        javaOpts,
 			javaOptsEnvVar:               javaOpts,
 		},

--- a/odiglet/pkg/instrumentation/instrumentlang/nodejs.go
+++ b/odiglet/pkg/instrumentation/instrumentlang/nodejs.go
@@ -2,6 +2,7 @@ package instrumentlang
 
 import (
 	"fmt"
+
 	"github.com/keyval-dev/odigos/odiglet/pkg/env"
 	"github.com/keyval-dev/odigos/odiglet/pkg/instrumentation/consts"
 	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -25,7 +26,7 @@ func NodeJS(deviceId string) *v1beta1.ContainerAllocateResponse {
 			nodeEnvTraceExporter:      "otlp",
 			nodeEnvEndpoint:           otlpEndpoint,
 			nodeEnvServiceName:        deviceId,
-			nodeEnvResourceAttributes: "odigos.device=nodejs",
+			nodeEnvResourceAttributes: fmt.Sprintf("odigos.device=nodejs,%s", getAdditionalResourceAttributes()),
 			nodeEnvNodeOptions:        fmt.Sprintf("--require %s/autoinstrumentation.js", nodeMountPath),
 		},
 		Mounts: []*v1beta1.Mount{

--- a/odiglet/pkg/instrumentation/instrumentlang/python.go
+++ b/odiglet/pkg/instrumentation/instrumentlang/python.go
@@ -26,7 +26,7 @@ func Python(deviceId string) *v1beta1.ContainerAllocateResponse {
 			envLogCorrelation:                  "true",
 			envPythonPath:                      "/var/odigos/python/opentelemetry/instrumentation/auto_instrumentation:/var/odigos/python",
 			"OTEL_EXPORTER_OTLP_ENDPOINT":      otlpEndpoint,
-			"OTEL_RESOURCE_ATTRIBUTES":         fmt.Sprintf("service.name=%s,odigos.device=python", deviceId),
+			"OTEL_RESOURCE_ATTRIBUTES":         fmt.Sprintf("service.name=%s,odigos.device=python,%s", deviceId, getAdditionalResourceAttributes()),
 			envOtelTracesExporter:              envValOtelHttpExporter,
 			envOtelMetricsExporter:             envValOtelHttpExporter,
 			envOtelExporterOTLPTracesProtocol:  httpProtobufProtocol,


### PR DESCRIPTION
Fixes https://github.com/keyval-dev/odigos/issues/740

I added the ability to add extra attributes this helps when you want to add some attributes needed the destination. For example elastic APM requires you to add deployment.environment=<env name> if you have the same service in  different environments (dev, test, prod, etc ...)
