### PR TITLE
[docs]: Improves contributions docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,7 @@ go build -o odigos-backend && ./odigos-backend --port 8085 --debug --address 0.0
 - run:
 
 ```
+ npm install
  npm run dev
 ```
 


### PR DESCRIPTION
Fix #752

Added installation command before `build` command. i.e.,
```bash
npm install
```

[here](https://github.com/keyval-dev/odigos/blob/de3daf79e33f1f5ff8e5f97c3134aaeed01d6811/CONTRIBUTING.md?plain=1#L122)