### PR TITLE
feat(elasticsearch): remove hard-coded port 9200, validate URL input

### DIFF
--- a/autoscaler/controllers/gateway/config/elasticsearch_test.go
+++ b/autoscaler/controllers/gateway/config/elasticsearch_test.go
@@ -1,0 +1,50 @@
+package config_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyval-dev/odigos/autoscaler/controllers/gateway/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestElasticsearch_SanitizeURL(t *testing.T) {
+	tt := []struct {
+		_           struct{}
+		URL         string
+		ExpectedURL string
+	}{
+		{
+			URL:         "http://localhost:9200/",
+			ExpectedURL: "http://localhost:9200/",
+		},
+		{
+			URL:         "http://localhost",
+			ExpectedURL: "http://localhost",
+		},
+		{
+			URL:         "localhost",
+			ExpectedURL: "localhost",
+		},
+		{
+			URL:         "http://user:pass@localhost:9200",
+			ExpectedURL: "http://user:pass@localhost:9200",
+		},
+	}
+
+	var es config.Elasticsearch
+	ctx := context.Background()
+
+	for i := range tt {
+		tc := tt[i]
+		t.Run(tc.URL, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			actualURL, actualErr := es.SanitizeURL(ctx, tc.URL)
+			r.NoError(actualErr)
+			r.Equal(tc.ExpectedURL, actualURL)
+
+		})
+	}
+}


### PR DESCRIPTION
This PR enables a flexible ES endpoints by removing hard-coded ES port in the endpoints section. This PR also sanitize/validate whether user input a valid URL or not by utilizing `url.Parse`. I'm wondering whether we do need to have a test or not since `url.Parse` function already have their own [test](https://cs.opensource.google/go/go/+/refs/tags/go1.21.6:src/net/url/url_test.go)

Please advise if we need more test cases

This PR will close #940