### PR TITLE
Remove go mod verify in Odiglet Dockerfile

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -21,21 +21,12 @@ COPY api/ api/
 COPY common/ common/
 COPY procdiscovery/ procdiscovery/
 WORKDIR /go/src/github.com/keyval-dev/odigos/odiglet
-# Pre-copy/cache go.mod for pre-downloading dependencies and only redownloading
-# them in subsequent builds if they change
-COPY odiglet/go.mod odiglet/go.sum ./
-RUN --mount=type=cache,target=/go/pkg \
-    go mod download
-# Copy rest of source code
 COPY odiglet/ .
 
 ARG TARGETARCH
-# Go does not call go generate on dependencies, so we need to do it manually
-RUN --mount=type=cache,target=/go/pkg \
-    cd $(go list -m -f '{{.Dir}}' "go.opentelemetry.io/auto") && make generate
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    GOOS=linux GOARCH=$TARGETARCH go build -o odiglet cmd/main.go
+    GOOS=linux GOARCH=$TARGETARCH make build-odiglet
 
 WORKDIR /instrumentations
 

--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /go/src/github.com/keyval-dev/odigos/odiglet
 # them in subsequent builds if they change
 COPY odiglet/go.mod odiglet/go.sum ./
 RUN --mount=type=cache,target=/go/pkg \
-    go mod download && go mod verify
+    go mod download
 # Copy rest of source code
 COPY odiglet/ .
 

--- a/odiglet/Makefile
+++ b/odiglet/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build-odiglet generate
+
+build-odiglet: generate
+	go build -o odiglet cmd/main.go
+
+generate:
+	go mod download
+	GO_AUTO_PATH=$$(go list -m -f '{{.Dir}}' "go.opentelemetry.io/auto") && \
+	cd $$GO_AUTO_PATH && \
+	make generate

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /go/src/github.com/keyval-dev/odigos
 COPY . .
 WORKDIR ./odiglet/
 RUN --mount=type=cache,target=/go/pkg \
-    go mod download && go mod verify
+    go mod download
 # Go does not call go generate on dependencies, so we need to do it manually
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \


### PR DESCRIPTION
After #1005, calling `go mod verify` can cause the build to break (since the downloaded packages are cached and modified by calling `make generate`)