### PR TITLE
fix: fix autoscaler reconciliation loop with patching collector groups instead of updating them

### DIFF
--- a/api/odigos/v1alpha1/collectorsgroup_types.go
+++ b/api/odigos/v1alpha1/collectorsgroup_types.go
@@ -39,6 +39,7 @@ type CollectorsGroupStatus struct {
 	Ready bool `json:"ready,omitempty"`
 }
 
+//+genclient
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 

--- a/autoscaler/controllers/datacollection/root.go
+++ b/autoscaler/controllers/datacollection/root.go
@@ -73,8 +73,8 @@ func syncDataCollection(instApps *odigosv1.InstrumentedApplicationList, dests *o
 	}
 
 	if err := c.Status().Patch(ctx, dataCollection, client.RawPatch(
-		types.JSONPatchType,
-		[]byte(fmt.Sprintf(`[{"op": "replace", "path": "/status/ready", "value": %t }]`, calcDataCollectionReadyStatus(ds))),
+		types.MergePatchType,
+		[]byte(fmt.Sprintf(`{"status": { "ready": %t }}`, calcDataCollectionReadyStatus(ds))),
 	)); err != nil {
 		logger.Error(err, "Failed to update data collection status")
 		return err

--- a/autoscaler/controllers/datacollection/root.go
+++ b/autoscaler/controllers/datacollection/root.go
@@ -16,7 +16,7 @@ func Sync(ctx context.Context, c client.Client, scheme *runtime.Scheme, imagePul
 	logger := log.FromContext(ctx)
 	var collectorGroups odigosv1.CollectorsGroupList
 	if err := c.List(ctx, &collectorGroups); err != nil {
-		logger.Error(err, "failed to list collectors groups")
+		logger.Error(err, "Failed to list collectors groups")
 		return err
 	}
 
@@ -29,25 +29,25 @@ func Sync(ctx context.Context, c client.Client, scheme *runtime.Scheme, imagePul
 	}
 
 	if dataCollectionCollectorGroup == nil {
-		logger.V(3).Info("data collection collector group doesn't exist, nothing to sync")
+		logger.V(3).Info("Data collection collector group doesn't exist, nothing to sync")
 		return nil
 	}
 
 	var instApps odigosv1.InstrumentedApplicationList
 	if err := c.List(ctx, &instApps); err != nil {
-		logger.Error(err, "failed to list instrumented apps")
+		logger.Error(err, "Failed to list instrumented apps")
 		return err
 	}
 
 	var dests odigosv1.DestinationList
 	if err := c.List(ctx, &dests); err != nil {
-		logger.Error(err, "failed to list destinations")
+		logger.Error(err, "Failed to list destinations")
 		return err
 	}
 
 	var processors odigosv1.ProcessorList
 	if err := c.List(ctx, &processors); err != nil {
-		logger.Error(err, "failed to list processors")
+		logger.Error(err, "Failed to list processors")
 		return err
 	}
 
@@ -58,17 +58,17 @@ func syncDataCollection(instApps *odigosv1.InstrumentedApplicationList, dests *o
 	dataCollection *odigosv1.CollectorsGroup, ctx context.Context, c client.Client,
 	scheme *runtime.Scheme, imagePullSecrets []string, odigosVersion string) error {
 	logger := log.FromContext(ctx)
-	logger.V(0).Info("syncing data collection")
+	logger.V(0).Info("Syncing data collection")
 
 	configData, err := syncConfigMap(instApps, dests, processors, dataCollection, ctx, c, scheme)
 	if err != nil {
-		logger.Error(err, "failed to sync config map")
+		logger.Error(err, "Failed to sync config map")
 		return err
 	}
 
 	ds, err := syncDaemonSet(instApps, dests, dataCollection, configData, ctx, c, scheme, imagePullSecrets, odigosVersion)
 	if err != nil {
-		logger.Error(err, "failed to sync daemon set")
+		logger.Error(err, "Failed to sync daemon set")
 		return err
 	}
 

--- a/autoscaler/controllers/gateway/root.go
+++ b/autoscaler/controllers/gateway/root.go
@@ -2,9 +2,11 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 
 	odigosv1 "github.com/keyval-dev/odigos/api/odigos/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -80,6 +82,8 @@ func syncGateway(dests *odigosv1.DestinationList, processors *odigosv1.Processor
 		return err
 	}
 
-	gateway.Status.Ready = dep.Status.ReadyReplicas > 0
-	return c.Status().Update(ctx, gateway)
+	return c.Status().Patch(ctx, gateway, client.RawPatch(
+		types.JSONPatchType,
+		[]byte(fmt.Sprintf(`[{"op": "replace", "path": "/status/ready", "value": %t }]`, dep.Status.ReadyReplicas > 0)),
+	))
 }

--- a/autoscaler/controllers/gateway/root.go
+++ b/autoscaler/controllers/gateway/root.go
@@ -83,7 +83,7 @@ func syncGateway(dests *odigosv1.DestinationList, processors *odigosv1.Processor
 	}
 
 	return c.Status().Patch(ctx, gateway, client.RawPatch(
-		types.JSONPatchType,
-		[]byte(fmt.Sprintf(`[{"op": "replace", "path": "/status/ready", "value": %t }]`, dep.Status.ReadyReplicas > 0)),
+		types.MergePatchType,
+		[]byte(fmt.Sprintf(`{"status": { "ready": %t }}`, dep.Status.ReadyReplicas > 0)),
 	))
 }

--- a/autoscaler/controllers/gateway/root.go
+++ b/autoscaler/controllers/gateway/root.go
@@ -26,7 +26,7 @@ func Sync(ctx context.Context, client client.Client, scheme *runtime.Scheme, ima
 	logger := log.FromContext(ctx)
 	var collectorGroups odigosv1.CollectorsGroupList
 	if err := client.List(ctx, &collectorGroups); err != nil {
-		logger.Error(err, "failed to list collectors groups")
+		logger.Error(err, "Failed to list collectors groups")
 		return err
 	}
 
@@ -39,19 +39,19 @@ func Sync(ctx context.Context, client client.Client, scheme *runtime.Scheme, ima
 	}
 
 	if gatewayCollectorGroup == nil {
-		logger.V(3).Info("gateway collector group doesn't exist, nothing to sync")
+		logger.V(3).Info("Gateway collector group doesn't exist, nothing to sync")
 		return nil
 	}
 
 	var dests odigosv1.DestinationList
 	if err := client.List(ctx, &dests); err != nil {
-		logger.Error(err, "failed to list destinations")
+		logger.Error(err, "Failed to list destinations")
 		return err
 	}
 
 	var processors odigosv1.ProcessorList
 	if err := client.List(ctx, &processors); err != nil {
-		logger.Error(err, "failed to list processors")
+		logger.Error(err, "Failed to list processors")
 		return err
 	}
 
@@ -62,23 +62,23 @@ func syncGateway(dests *odigosv1.DestinationList, processors *odigosv1.Processor
 	gateway *odigosv1.CollectorsGroup, ctx context.Context,
 	c client.Client, scheme *runtime.Scheme, imagePullSecrets []string, odigosVersion string) error {
 	logger := log.FromContext(ctx)
-	logger.V(0).Info("syncing gateway")
+	logger.V(0).Info("Syncing gateway")
 
 	configData, err := syncConfigMap(dests, processors, gateway, ctx, c, scheme)
 	if err != nil {
-		logger.Error(err, "failed to sync config map")
+		logger.Error(err, "Failed to sync config map")
 		return err
 	}
 
 	_, err = syncService(gateway, ctx, c, scheme)
 	if err != nil {
-		logger.Error(err, "failed to sync service")
+		logger.Error(err, "Failed to sync service")
 		return err
 	}
 
 	dep, err := syncDeployment(dests, gateway, configData, ctx, c, scheme, imagePullSecrets, odigosVersion)
 	if err != nil {
-		logger.Error(err, "failed to sync deployment")
+		logger.Error(err, "Failed to sync deployment")
 		return err
 	}
 


### PR DESCRIPTION
- **feat: implement status patch and use it instead of updating the whole data collection**
- **feat: generate client for colletorsgroup crd**
- **style: capitalize error messages**

Not exactly idiomatic to this codebase, but works™. Also the `genclient` is not required, but I saw that annotation on every other CRD during my investigation, so added it there for symmetry. Maybe it'll be useful in the future.
