### PR TITLE
Adds the missing commands in Generating data page

### DIFF
--- a/docs/quickstart/generation-data.mdx
+++ b/docs/quickstart/generation-data.mdx
@@ -5,7 +5,14 @@ sidebarTitle: "Generating Data"
 
 ## Wait for collectors to be ready
 
-Before generating data, make sure that the collectors and applications are ready:
+Before generating data, make sure that the collectors and applications are ready. To check this run the following command:
+
+```bash
+kubectl get pods -n default
+```
+```bash
+kubectl get pods -n odigos-system
+```
 
 <Frame>
     <img src="/images/collectors_ready.png" alt="Wait for collectors to be ready" />


### PR DESCRIPTION
Fixes #1096

Added commands for consistency in the documentation:
```bash
kubectl get pods -n default
```
```bash
kubectl get pods -n odigos-system
```