### PR TITLE
chore: update Java Agent to the latest 1.x version

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 WORKDIR /instrumentations
 
 # Java
-ARG JAVA_OTEL_VERSION=v1.29.0
+ARG JAVA_OTEL_VERSION=v1.33.1
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$JAVA_OTEL_VERSION/opentelemetry-javaagent.jar /instrumentations/java/javaagent.jar
 RUN chmod 644 /instrumentations/java/javaagent.jar
 

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -34,7 +34,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /instrumentations
 
 # Java
-ARG JAVA_OTEL_VERSION=v1.29.0
+ARG JAVA_OTEL_VERSION=v1.33.1
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$JAVA_OTEL_VERSION/opentelemetry-javaagent.jar /instrumentations/java/javaagent.jar
 RUN chmod 644 /instrumentations/java/javaagent.jar
 


### PR DESCRIPTION
I'm looking into updating Java Agent to v2.x soon. Until that, it doesn't hurt to upgrade it to the latest 1.x release.