### PR TITLE
revert: using specific helm chart for e2e testing

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,8 +46,6 @@ jobs:
         with:
           repository: 'open-telemetry/opentelemetry-helm-charts'
           path: opentelemetry-helm-charts
-          # Remove once open-telemetry/opentelemetry-helm-charts#1143 is merged
-          ref: e0c6b9c95c4c4710c3d986e56b9e86ff32de6210
       - name: Install Collector - Helm install
         run: helm install test -f .github/workflows/e2e/collector-helm-values.yaml opentelemetry-helm-charts/charts/opentelemetry-collector --namespace traces --create-namespace
       - name: Wait for Collector to be ready


### PR DESCRIPTION
It was introduced as a workaround fix until https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1143 is merged, due to an bug introduced via https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1139 which broke odigos ci